### PR TITLE
Update `mosdepth` target-regions

### DIFF
--- a/workflows/modules/qc_modules/mosdepth.nf
+++ b/workflows/modules/qc_modules/mosdepth.nf
@@ -12,6 +12,7 @@ process mosdepth {
     path(BAI)
     path(REF)
     val(REF_MAP)
+    path(TARGET_REGIONS)
     val(PROCESSOR)
 
     output:

--- a/workflows/qc_cpu.nf
+++ b/workflows/qc_cpu.nf
@@ -62,7 +62,7 @@ workflow {
     BAI_FILE = Channel.fromPath(params.bai_path)
     genome_folder = Channel.fromPath(params.genome_folder)
     S_NAME = Channel.from(params.sample_name)
-    TARGET_REGIONS = Channel.from(params.target_regions)
+    TARGET_REGIONS = Channel.fromPath(params.target_regions)
 
     fastqc(input_fqs, PROCESSOR)
 
@@ -81,7 +81,7 @@ workflow {
     )
 
     mosdepth(
-        S_NAME, BAM_FILE, BAI_FILE, genome_folder, reference_map, PROCESSOR
+        S_NAME, BAM_FILE, BAI_FILE, genome_folder, reference_map, TARGET_REGIONS, PROCESSOR
     )
 
     gatk_collectInsertSizeMetrics(
@@ -89,7 +89,7 @@ workflow {
     )
 
     gatk_collectAlignmentSummaryMetrics(
-        S_NAME, BAM_FILE, BAI_FILE, genome_folder, reference_map, TARGET_REGIONS, PROCESSOR
+        S_NAME, BAM_FILE, BAI_FILE, genome_folder, reference_map, PROCESSOR
     )
 
     multiqc(

--- a/workflows/qc_cpu.nf
+++ b/workflows/qc_cpu.nf
@@ -19,6 +19,7 @@ def PROCESSOR = "CPU"
 def helpMessage() {
     log.info"""
 Usage:
+  --help                Print this help message
 
   Input Data:
   --fastq_folder        Folder containing paired-end FASTQ files ending with .fastq.gz,
@@ -31,6 +32,9 @@ Usage:
   --genome_folder       Folder containing reference genome and other reference files
   --genome_json         JSON file listing reference files available in --genome_folder
                         (Use reference_data.josn provided in this pipeline or follow the same format)
+
+  Optional parameters:
+  --target_regions      Genomic regions targeted by the assay/exome capture kit
 
     """.stripIndent()
 }
@@ -58,6 +62,7 @@ workflow {
     BAI_FILE = Channel.fromPath(params.bai_path)
     genome_folder = Channel.fromPath(params.genome_folder)
     S_NAME = Channel.from(params.sample_name)
+    TARGET_REGIONS = Channel.from(params.target_regions)
 
     fastqc(input_fqs, PROCESSOR)
 
@@ -84,7 +89,7 @@ workflow {
     )
 
     gatk_collectAlignmentSummaryMetrics(
-        S_NAME, BAM_FILE, BAI_FILE, genome_folder, reference_map, PROCESSOR
+        S_NAME, BAM_FILE, BAI_FILE, genome_folder, reference_map, TARGET_REGIONS, PROCESSOR
     )
 
     multiqc(

--- a/workflows/templates/mosdepth.sh
+++ b/workflows/templates/mosdepth.sh
@@ -4,12 +4,18 @@ set -euo pipefail
 
 FASTA=${REF}"/"${REF_MAP["reference_fasta"]["dict"]}
 
-awk 'BEGIN{OFS="\\t"}{if ((\$2 !~ /_/) && (\$1 !~ /HD/) ) {split(\$2,a,":"); split(a[2],b,"_"); split(\$3,c,":"); print b[1], 1, c[2]}}' \${FASTA} > intervals.bed
+
+if [ -f ${TARGET_REGIONS} ]; then
+    INTERVALS="--by ${TARGET_REGIONS}" 
+else
+	awk 'BEGIN{OFS="\\t"}{if ((\$2 !~ /_/) && (\$1 !~ /HD/) ) {split(\$2,a,":"); split(a[2],b,"_"); split(\$3,c,":"); print b[1], 1, c[2]}}' \${FASTA} > intervals.bed
+    INTERVALS="--by intervals.bed"
+fi
 
 mosdepth \
 	-n \
 	--threads ${task.cpus} \
-	--by intervals.bed \
+	\${INTERVALS} \
 	--thresholds 1,10,20,30,50,100,150,200,250,300 \
 	"mosdepth" \
 	${BAM}


### PR DESCRIPTION
Updated `mosdepth` to accept the target region file when available. This helps `mosdepth` to calculate read counts in target regions and eventually calculate mean coverage across only on targets. i.e., Reports correct mean coverage across target regions and avoids reporting lower mean coverage due to the calculations across the chromosomes. 

Tested on 150x sample 
<img width="1498" alt="image" src="https://github.com/NAICNO/clara_parabricks/assets/4319108/379afd39-917e-49d3-b265-47366fd8ffa1">
