### PR TITLE
Specify GPU device(s) visible to docker 

### DIFF
--- a/workflows/conf/docker.conf
+++ b/workflows/conf/docker.conf
@@ -2,16 +2,32 @@ process {
     
     docker.runOptions = '-u $(id -u):$(id -g)'
 
+    // Parabricks configurations
+    // Specify the GPU devices visible to each process
+    withName:'pbrun_fq2bam' {
+        container = "nvcr.io/nvidia/clara/clara-parabricks:4.3.0-1"
+        containerOptions = '--gpus \'"device=0,1,2,3"\'  --rm'
+    }
+    withName:'pbrun_applybqsr' {
+        container = "nvcr.io/nvidia/clara/clara-parabricks:4.3.0-1"
+        containerOptions = '--gpus \'"device=0"\' --rm'
+    }
+    withName:'pbrun_haplotypecaller' {
+        container = "nvcr.io/nvidia/clara/clara-parabricks:4.3.0-1"
+        containerOptions = '--gpus \'"device=0,1,2,3"\' --rm'
+    }
+    withName:'pbrun_deepvariant' {
+        container = "nvcr.io/nvidia/clara/clara-parabricks:4.3.0-1"
+        containerOptions = '--gpus \'"device=0,1,2,3"\' --rm'
+    }
+
+
     withName:'bwa' {
         container = "pubudusaneth/bwa_samtools_amd64:v0.7.17.v1.18"
         // Source: https://github.com/NAICNO/NAIC-Dockerfiles/blob/main/bwa-samtools/Dockerfile
     }
     withName:'gatk_.*' {
         container = "docker.io/broadinstitute/gatk:4.3.0.0"
-    }
-    withName:'pbrun_.*' {
-        container = "nvcr.io/nvidia/clara/clara-parabricks:4.3.0-1"
-        containerOptions = '--gpus all --rm'
     }
     withName:"deepvariant" {
         container = "google/deepvariant:1.5.0"

--- a/workflows/conf/resource.conf
+++ b/workflows/conf/resource.conf
@@ -30,14 +30,28 @@ process {
         cpus='12'
     }
 
+    // Parabricks configurations
+    // Specify resources for each process
+
+    withName:'pbrun_fq2bam' {
+        memory='120 GB'
+        cpus='42'
+        gpu='4'
+    }
     // pbrun_applybqsr is recommended to run on 1 GPU
     withName:'pbrun_applybqsr' {
+        memory='120 GB'
+        cpus='42'
         gpu='1'
     }
     withName:'pbrun_deepvariant' {
+        memory='120 GB'
+        cpus='42'
         gpu='4'
     }
     withName:'pbrun_haplotypecaller' {
+        memory='120 GB'
+        cpus='42'
         gpu='4'
     }
     


### PR DESCRIPTION
* Allow users to specify the GPU devices visible to each docker process
* Specify the number of CPU cores and memory (resident) for each parabricks process

**Testing the updated config files on L4 - 4 GPU machine:**
```
\\ docker.conf
    withName:'pbrun_fq2bam' {
        container = "nvcr.io/nvidia/clara/clara-parabricks:4.3.0-1"
        containerOptions = '--gpus \'"device=0,1,2"\'  --rm'
    }

\\resources.conf
    withName:'pbrun_fq2bam' {
        memory='120 GB'
        cpus='42'
        gpu='3'
    }
``` 
**Checking the work-folder:**
* Docker run command showed correct GPU count and device IDs and memory 
```
$ grep docker .command.run
    docker rm $NXF_BOXID &>/dev/null || true
    docker stop $NXF_BOXID
    docker run -i --cpu-shares 43008 --memory 122880m -e "NXF_TASK_WORKDIR" -e "NXF_DEBUG=${NXF_DEBUG:=0}" -v /data/data:/data/data -w "$NXF_TASK_WORKDIR" -u $(id -u):$(id -g) --gpus '"device=0,1,2"'  --rm --name $NXF_BOXID nvcr.io/nvidia/clara/clara-parabricks:4.3.0-1 /bin/bash /data/data/analysis_h100/NA12878_3/work/8c/00730b6172ef03422b422f1aa4fdfa/.command.run nxf_trace
```
* `NVIDIA-smi` inside docker container also showed the GPU devices with the specified IDs
```
docker run -it --cpu-shares 43008 --memory 122880m -e "NXF_TASK_WORKDIR" -e "NXF_DEBUG=${NXF_DEBUG:=0}" -v /data/data:/data/data -w $PWD -u $(id -u):$(id -g) --gpus '"device=0,1,2"'  --rm  nvcr.io/nvidia/clara/clara-parabricks:4.3.0-1 /bin/bash

$ nvidia-smi
Fri Sep  6 10:00:41 2024
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 550.90.07              Driver Version: 550.90.07      CUDA Version: 12.4     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA L4                      On  |   00000000:00:03.0 Off |                    0 |
| N/A   74C    P0             60W /   72W |   16169MiB /  23034MiB |     61%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA L4                      On  |   00000000:00:04.0 Off |                    0 |
| N/A   76C    P0             60W /   72W |   16169MiB /  23034MiB |     90%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
|   2  NVIDIA L4                      On  |   00000000:00:05.0 Off |                    0 |
| N/A   78C    P0             65W /   72W |   16169MiB /  23034MiB |     54%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
``` 