### PR TITLE
Add Optimized ParabricksHC

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,11 @@ NAIC Accelerated Genomics is a scalable and reproducible suite of GPU-enabled Ne
     ├── data                    <- Data directory
     │   ├── external_testdata   <- Test-data from third-party sources
     │   ├── internal_testdata   <- Intermediate Test-data 
-    │   ├── processed           <- The final, canonical data sets for modeling
     │
     ├── tools                   <- Bioinformatics tools used in NVIDIA Parabricks
     │
     ├── references              <- User guide, manuals, and all other explanatory materials
     ├── workflows               <- Collection of scalable and reproducible workflows/pipelines that automate complex NGS raw-data processing tasks 
-    |
-    ├── notebooks               <- Jupyter notebooks with detailed analysis
-    |
-    |     *NOTE:  NOT YET IMPLEMENTED*
-    |
-    ├── reports                 <- *NOTE:  NOT YET IMPLEMENTED (Generated analysis as HTML, PDF, LaTeX, etc.)*
-    │   └── figures             <- *Generated graphics and figures to be used in reporting*
 
 --------
 
@@ -125,6 +117,7 @@ To conduct germline sequence analysis using GPUs, execute the following command:
 * Accelerated germline pipeline is tested on following Parabricks versions:
   * Parabricks v.4.2.1
   * Parabricks v.4.3.0
+  * parabricks v.4.3.0-1
 
 #### Additional Resources: Accelerated germline pipeline (GPU pipeline)
 
@@ -144,6 +137,21 @@ To initiate the CPU-based germline sequence analysis, use the command below with
   --genome_json <JSON listing reference files> \
   --processor CPU \
   --target_regions <"path to the target region file"> \
+  -with-report \
+  -with-trace \
+  -resume
+```
+
+### Optimized Parabricks HaplotypeCaller pipeline
+
+Proof-of-concept workflow that executes Parabricks HaplotypeCaller concurrently across multiple chromosomes.
+
+```bash
+  ./nextflow run \
+  parabricks_optimized_hc.nf \
+  -profile docker \
+  --fasta <"path to the reference sequence"> \
+  --bam <"path to the BAM file to call variants"> \
   -with-report \
   -with-trace \
   -resume

--- a/workflows/conf/docker.conf
+++ b/workflows/conf/docker.conf
@@ -20,7 +20,10 @@ process {
         container = "nvcr.io/nvidia/clara/clara-parabricks:4.3.0-1"
         containerOptions = '--gpus \'"device=0,1,2,3"\' --rm'
     }
-
+    withName:'optimized_hc' {
+        container = "nvcr.io/nvidia/clara/clara-parabricks:4.3.0-1"
+        containerOptions = '--gpus all --rm'
+    }
 
     withName:'bwa' {
         container = "pubudusaneth/bwa_samtools_amd64:v0.7.17.v1.18"
@@ -31,6 +34,10 @@ process {
     }
     withName:"deepvariant" {
         container = "google/deepvariant:1.5.0"
+    }
+    withName:'samtools_.*' {
+        container = "pubudusaneth/bwa_samtools_amd64:v0.7.17.v1.18"
+        // Source: https://github.com/NAICNO/NAIC-Dockerfiles/blob/main/bwa-samtools/Dockerfile
     }
 
     // QC tools

--- a/workflows/conf/resource.conf
+++ b/workflows/conf/resource.conf
@@ -23,7 +23,8 @@ process {
     }
     withName:'samtools_.*' {
         memory='80 GB'
-        cpus='12'
+        cpus='20'
+        maxForks = 16  // Allow up to 16 parallel instances
     }
     withName:'multiqc' {
         memory='80 GB'
@@ -53,6 +54,11 @@ process {
         memory='412 GB'
         cpus='96'
         gpu='4'
+    }
+    withName:'optimized_hc' {
+        memory='412 GB'
+        cpus='40'
+        maxForks = 16  // Allow up to 16 parallel instances
     }
     
 }

--- a/workflows/modules/cpu_pipelines/samtools_split_bam.nf
+++ b/workflows/modules/cpu_pipelines/samtools_split_bam.nf
@@ -1,0 +1,21 @@
+#!/usr/bin/env nextflow
+
+// Using DSL-2
+nextflow.enable.dsl=2
+
+// Process to split BAM by chromosome - now parallelized
+process split_bam_by_chromosome {
+    tag "chr${chromosome}"
+    
+    input:
+    tuple val(chromosome), path(bam), path(bai)
+
+    output:
+    tuple val(chromosome), path("chr${chromosome}.bam"), path("chr${chromosome}.bam.bai"), emit: split_bams
+
+    script:
+    """
+    samtools view -@${task.cpus} -b ${bam} chr${chromosome} > chr${chromosome}.bam
+    samtools index -@${task.cpus} -b  chr${chromosome}.bam
+    """
+}

--- a/workflows/modules/gpu_pipelines/pbrun_optimized_hc.nf
+++ b/workflows/modules/gpu_pipelines/pbrun_optimized_hc.nf
@@ -1,0 +1,39 @@
+#!/usr/bin/env nextflow
+
+// Using DSL-2
+nextflow.enable.dsl=2
+
+// Process to run GATK HaplotypeCaller on a split BAM files
+process optimized_hc {
+    tag "chr${chr}"
+    publishDir "${params.outdir}/vcfs", mode: 'copy'
+    
+    input:
+    tuple val(chr), path(bam), path(bam_index)
+    each path(fasta)
+    each path(fasta_index)
+    each path(fasta_dict)
+
+    output:
+    tuple path("${bam.baseName}.vcf"), path("${bam.baseName}.log") 
+
+    script:
+    // Calculate paired GPU devices based on task index
+    // With 8 GPUs total, we can run 4 concurrent processes (2 GPUs each)
+    def start_gpu = (task.index % 4) * 2  // Will give us 0,2,4,6 as starting GPUs
+    def gpu_pair = "${start_gpu},${start_gpu + 1}"  // Pairs will be 0,1 or 2,3 or 4,5 or 6,7
+
+    """
+    echo "Start time: \$(date)" > ${bam.baseName}.log
+
+    export CUDA_VISIBLE_DEVICES=${gpu_pair}
+
+    pbrun haplotypecaller \
+        --ref ${fasta} \
+        --num-gpus 2 \
+        --in-bam ${bam} \
+        --out-variants  ${bam.baseName}.vcf
+
+    echo "End time: \$(date)" >> ${bam.baseName}.log
+    """
+}

--- a/workflows/modules/gpu_pipelines/pbrun_optimized_hc.nf
+++ b/workflows/modules/gpu_pipelines/pbrun_optimized_hc.nf
@@ -20,7 +20,7 @@ process optimized_hc {
     script:
     // Calculate paired GPU devices based on task index
     // With 8 GPUs total, we can run 4 concurrent processes (2 GPUs each)
-    def start_gpu = (task.index % 4) * 2  // Will give us 0,2,4,6 as starting GPUs
+    def start_gpu = (task.index % 4) * 2  // (task.index % 4) * 2 = 0 * 2, 1 * 2, 2 * 2, 3 * 2 = 0, 2, 4, 6
     def gpu_pair = "${start_gpu},${start_gpu + 1}"  // Pairs will be 0,1 or 2,3 or 4,5 or 6,7
 
     """

--- a/workflows/parabricks_optimized_hc.nf
+++ b/workflows/parabricks_optimized_hc.nf
@@ -1,0 +1,44 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl=2
+
+// Default parameters
+params.bam = null
+params.fasta = null
+params.outdir = 'Results'
+params.chromosomes = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', 
+                     '11', '12', '13', '14', '15', '16', '17', '18', '19', 
+                     '20', '21', '22', 'X', 'Y']
+
+// Import sub-workflows
+include { optimized_hc            } from './modules/gpu_pipelines/pbrun_optimized_hc'
+include { split_bam_by_chromosome } from './modules/cpu_pipelines/samtools_split_bam'
+
+workflow {
+    // Input channels
+    bam_ch = channel.fromPath(params.bam)
+    bai_ch = channel.fromPath(params.bai)
+    fasta_ch = channel.fromPath(params.fasta)
+    fasta_index_ch = channel.fromPath("${params.fasta}.fai")
+    fasta_dict_ch = channel.fromPath("${params.fasta.replaceAll(/\.fa(sta)?$/, '')}.dict")
+
+    // Create a channel combining chromosomes with the input BAM
+    chr_bam_ch = channel
+        .fromList(params.chromosomes)
+        .combine(bam_ch)
+        .combine(bai_ch)
+
+    // Split BAM by chromosome (runs in parallel)
+    split_bams = split_bam_by_chromosome(chr_bam_ch)
+        .split_bams
+        .map { chr, bam, bai -> tuple(chr, bam, bai) }
+
+    // Run HaplotypeCaller on each split BAM (runs in parallel)
+    optimized_hc(
+        split_bams,
+        fasta_ch,
+        fasta_index_ch,
+        fasta_dict_ch
+    )
+
+}


### PR DESCRIPTION
Proof-of-concept workflow that executes Parabricks HaplotypeCaller concurrently across multiple chromosomes.
(Workflow detailed in the manuscript)

```bash
  ./nextflow run \
  parabricks_optimized_hc.nf \
  -profile docker \
  --fasta <"path to the reference sequence"> \
  --bam <"path to the BAM file to call variants"> \
  -with-report \
  -with-trace \
  -resume
```